### PR TITLE
[FEATURE] 이메일 인증 적용 전 회원가입 로직 구현

### DIFF
--- a/src/main/java/hackerton/wakeup/member/controller/MemberController.java
+++ b/src/main/java/hackerton/wakeup/member/controller/MemberController.java
@@ -1,0 +1,13 @@
+package hackerton.wakeup.member.controller;
+
+import hackerton.wakeup.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/member")
+public class MemberController {
+    private final MemberService memberService;
+}

--- a/src/main/java/hackerton/wakeup/member/controller/MemberController.java
+++ b/src/main/java/hackerton/wakeup/member/controller/MemberController.java
@@ -1,7 +1,13 @@
 package hackerton.wakeup.member.controller;
 
+import hackerton.wakeup.member.entity.dto.request.JoinRequestDTO;
 import hackerton.wakeup.member.service.MemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,4 +16,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/member")
 public class MemberController {
     private final MemberService memberService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> join(@Valid @RequestBody JoinRequestDTO req){
+        if (memberService.checkEmailDuplication(req.getEmail())){
+            return new ResponseEntity<>("이메일 중복", HttpStatus.BAD_REQUEST);
+        }
+        if (!req.getPassword().equals(req.getCheckPassword())){
+            return new ResponseEntity<>("비밀번호 불일치", HttpStatus.BAD_REQUEST);
+        }
+        memberService.joinMember(req);
+        return ResponseEntity.ok("회원가입 성공");
+    }
 }

--- a/src/main/java/hackerton/wakeup/member/entity/dto/request/JoinRequestDTO.java
+++ b/src/main/java/hackerton/wakeup/member/entity/dto/request/JoinRequestDTO.java
@@ -1,0 +1,9 @@
+package hackerton.wakeup.member.entity.dto.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class JoinRequestDTO {
+}

--- a/src/main/java/hackerton/wakeup/member/entity/dto/request/JoinRequestDTO.java
+++ b/src/main/java/hackerton/wakeup/member/entity/dto/request/JoinRequestDTO.java
@@ -7,6 +7,11 @@ import lombok.*;
 @Setter
 @NoArgsConstructor
 public class JoinRequestDTO {
+
     @NotBlank(message = "이메일이 비어있습니다.")
     private String email;
+
+    @NotBlank(message = "비밀번호가 비어있습니다.")
+    private String password;
+    private String checkPassword;
 }

--- a/src/main/java/hackerton/wakeup/member/entity/dto/request/JoinRequestDTO.java
+++ b/src/main/java/hackerton/wakeup/member/entity/dto/request/JoinRequestDTO.java
@@ -1,9 +1,12 @@
 package hackerton.wakeup.member.entity.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor
 public class JoinRequestDTO {
+    @NotBlank(message = "이메일이 비어있습니다.")
+    private String email;
 }

--- a/src/main/java/hackerton/wakeup/member/entity/dto/request/JoinRequestDTO.java
+++ b/src/main/java/hackerton/wakeup/member/entity/dto/request/JoinRequestDTO.java
@@ -1,5 +1,6 @@
 package hackerton.wakeup.member.entity.dto.request;
 
+import hackerton.wakeup.member.entity.Member;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
@@ -14,4 +15,12 @@ public class JoinRequestDTO {
     @NotBlank(message = "비밀번호가 비어있습니다.")
     private String password;
     private String checkPassword;
+
+    public Member toEntity(){
+        return Member.builder()
+                .email(this.email)
+                .password(this.password)
+                .point(0)
+                .build();
+    }
 }

--- a/src/main/java/hackerton/wakeup/member/repository/MemberRepository.java
+++ b/src/main/java/hackerton/wakeup/member/repository/MemberRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/hackerton/wakeup/member/repository/MemberRepository.java
+++ b/src/main/java/hackerton/wakeup/member/repository/MemberRepository.java
@@ -1,4 +1,10 @@
 package hackerton.wakeup.member.repository;
 
-public interface MemberRepository {
+import hackerton.wakeup.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/hackerton/wakeup/member/repository/MemberRepository.java
+++ b/src/main/java/hackerton/wakeup/member/repository/MemberRepository.java
@@ -1,0 +1,4 @@
+package hackerton.wakeup.member.repository;
+
+public interface MemberRepository {
+}

--- a/src/main/java/hackerton/wakeup/member/service/MemberService.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberService.java
@@ -1,0 +1,4 @@
+package hackerton.wakeup.member.service;
+
+public interface MemberService {
+}

--- a/src/main/java/hackerton/wakeup/member/service/MemberService.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberService.java
@@ -1,7 +1,9 @@
 package hackerton.wakeup.member.service;
 
 import hackerton.wakeup.member.entity.Member;
+import hackerton.wakeup.member.entity.dto.request.JoinRequestDTO;
 
 public interface MemberService {
     boolean checkEmailDuplication(String email);
+    void joinMember(JoinRequestDTO req);
 }

--- a/src/main/java/hackerton/wakeup/member/service/MemberService.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberService.java
@@ -6,4 +6,6 @@ import hackerton.wakeup.member.entity.dto.request.JoinRequestDTO;
 public interface MemberService {
     boolean checkEmailDuplication(String email);
     void joinMember(JoinRequestDTO req);
+    Member getMemberById(Long id);
+    Member getMemberByEmail(String email);
 }

--- a/src/main/java/hackerton/wakeup/member/service/MemberService.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberService.java
@@ -1,4 +1,5 @@
 package hackerton.wakeup.member.service;
 
 public interface MemberService {
+    boolean checkEmailDuplication(String email);
 }

--- a/src/main/java/hackerton/wakeup/member/service/MemberService.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package hackerton.wakeup.member.service;
 
+import hackerton.wakeup.member.entity.Member;
+
 public interface MemberService {
     boolean checkEmailDuplication(String email);
 }

--- a/src/main/java/hackerton/wakeup/member/service/MemberService.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberService.java
@@ -3,9 +3,11 @@ package hackerton.wakeup.member.service;
 import hackerton.wakeup.member.entity.Member;
 import hackerton.wakeup.member.entity.dto.request.JoinRequestDTO;
 
+import java.util.Optional;
+
 public interface MemberService {
     boolean checkEmailDuplication(String email);
     void joinMember(JoinRequestDTO req);
-    Member getMemberById(Long id);
-    Member getMemberByEmail(String email);
+    Optional<Member> getMemberById(Long id);
+    Optional<Member> getMemberByEmail(String email);
 }

--- a/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package hackerton.wakeup.member.service;
 
+import hackerton.wakeup.member.entity.Member;
 import hackerton.wakeup.member.entity.dto.request.JoinRequestDTO;
 import hackerton.wakeup.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +24,15 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public void joinMember(JoinRequestDTO req) {
         memberRepository.save(req.toEntity());
+    }
+
+    @Override
+    public Member getMemberById(Long id) {
+        return null;
+    }
+
+    @Override
+    public Member getMemberByEmail(String email) {
+        return null;
     }
 }

--- a/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
@@ -1,0 +1,23 @@
+package hackerton.wakeup.member.service;
+
+import hackerton.wakeup.member.entity.dto.request.JoinRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Primary
+public class MemberServiceImpl implements MemberService {
+    @Override
+    public boolean checkEmailDuplication(String email) {
+        return false;
+    }
+
+    @Override
+    public void joinMember(JoinRequestDTO req) {
+
+    }
+}

--- a/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
@@ -8,6 +8,8 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -27,12 +29,12 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public Member getMemberById(Long id) {
-        return null;
+    public Optional<Member> getMemberById(Long id) {
+        return memberRepository.findById(id);
     }
 
     @Override
-    public Member getMemberByEmail(String email) {
-        return null;
+    public Optional<Member> getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email);
     }
 }

--- a/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
@@ -22,6 +22,6 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public void joinMember(JoinRequestDTO req) {
-
+        memberRepository.save(req.toEntity());
     }
 }

--- a/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
@@ -1,6 +1,7 @@
 package hackerton.wakeup.member.service;
 
 import hackerton.wakeup.member.entity.dto.request.JoinRequestDTO;
+import hackerton.wakeup.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -11,6 +12,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Primary
 public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+
     @Override
     public boolean checkEmailDuplication(String email) {
         return false;

--- a/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
@@ -17,7 +17,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public boolean checkEmailDuplication(String email) {
-        return false;
+        return memberRepository.existsByEmail(email);
     }
 
     @Override


### PR DESCRIPTION
## 연관된 이슈

#5

## 작업 내용

 아직 이메일 인증이 들어가지 않은 회원가입 로직을 구현했습니다.
>
> 1. Repository
> > ![image](https://github.com/user-attachments/assets/4fdb7c68-b440-4714-9514-3ed9d9033939)
> > - Spring Data Jpa 사용
> > - 이메일 중복 확인 용도로 existsByEmail 메서드 추가
> > - Email로 멤버를 가져오는 findByEmail 메서드 추가
> 2. Service
> > ![image](https://github.com/user-attachments/assets/4acb13db-2860-4a77-ba07-8afcdab3e365)
> > - 이메일 중복 확인 용도로 checkEmailDuplication 메서드 추가
> > - DB에 새로운 멤버를 추가하는 joinMember 메서드 추가 
> > - DB에서 각각 id와 email로 멤버를 조회하는 getMemberById, getMemberByEmail 메서드 추가
> 3. DTO
> > ![image](https://github.com/user-attachments/assets/2efe460d-ea71-43a1-be6d-a2c17ec94c37)
> > - 회원가입시 사용될 DTO
> > - MemberEntity와 동일한 형태로 build 하는 toEntity 메서드 추가
> 4. Controller
> > ![image](https://github.com/user-attachments/assets/4b4e071e-6dc6-4503-aa5c-ae034017cfc1)
> > - /api/member/signup Path에 회원가입 메서드인 join 구현
> > - 이메일 중복이나 비밀번호 불일치시 400 BAD REQUEST를 반환 그렇지 않을 땐 DB에 추가 후 회원가입 성공 반환

## 기타(특이사항 등)
- Controller에 RequestMapping은 임의 경로로 설정해뒀습니다
### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/93332aff-67f9-45e3-b82f-cf2f2eca6725)

## 💬리뷰 요구사항(선택)
- Service에 조회하는 메서드명 앞에 각각 get을 사용했는데 null인 경우를 허용하니 find가 더 괜찮을까요?
- SpringSecurity를 이용한 password 암호화는 먼저 추가하는 게 좋을까요?