### PR TITLE
[FEATURE] 이메일인증 회원가입 개발

### DIFF
--- a/src/main/java/hackerton/wakeup/email/service/EmailVerifyServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/email/service/EmailVerifyServiceImpl.java
@@ -22,6 +22,7 @@ public class EmailVerifyServiceImpl implements EmailVerifyService {
     @Override
     public String generateVerificationCode(String email) {
         String code = randomCode();
+        verificationCodes.remove(email);
         verificationCodes.put(email, code);
 
         //일정 시간이 지나면 Map 에서 키를 삭제하는 로직 ( 수행 로직, 시간제한, 시간단위 )

--- a/src/main/java/hackerton/wakeup/member/controller/MemberController.java
+++ b/src/main/java/hackerton/wakeup/member/controller/MemberController.java
@@ -27,7 +27,7 @@ public class MemberController {
     }
 
     @PostMapping("/send-verification")
-    public ResponseEntity<String> sendVerification(@RequestParam String email){
+    public ResponseEntity<String> sendVerification(@RequestParam("email") String email){
         if (memberService.checkEmailDuplication(email)){
             return new ResponseEntity<>("이미 존재하는 이메일입니다.", HttpStatus.BAD_REQUEST);
         }

--- a/src/main/java/hackerton/wakeup/member/controller/MemberController.java
+++ b/src/main/java/hackerton/wakeup/member/controller/MemberController.java
@@ -6,10 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,5 +24,14 @@ public class MemberController {
         }
         memberService.joinMember(req);
         return ResponseEntity.ok("회원가입 성공");
+    }
+
+    @PostMapping("/send-verification")
+    public ResponseEntity<String> sendVerification(@RequestParam String email){
+        if (memberService.checkEmailDuplication(email)){
+            return new ResponseEntity<>("이미 존재하는 이메일입니다.", HttpStatus.BAD_REQUEST);
+        }
+        memberService.sendVerificationEmail(email);
+        return ResponseEntity.ok("인증코드가 이메일로 전송 되었습니다.");
     }
 }

--- a/src/main/java/hackerton/wakeup/member/entity/Member.java
+++ b/src/main/java/hackerton/wakeup/member/entity/Member.java
@@ -1,8 +1,7 @@
 package hackerton.wakeup.member.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.*;
 import lombok.*;
 
 @Entity
@@ -24,6 +23,7 @@ public class Member {
     @NotBlank
     private String password;
 
-    @NotBlank
+    @NotNull
+    @Min(0)
     private int point;
 }

--- a/src/main/java/hackerton/wakeup/member/entity/Member.java
+++ b/src/main/java/hackerton/wakeup/member/entity/Member.java
@@ -14,7 +14,6 @@ import lombok.*;
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @NotBlank
     private Long id;
 
     @Email

--- a/src/main/java/hackerton/wakeup/member/entity/dto/request/JoinRequestDTO.java
+++ b/src/main/java/hackerton/wakeup/member/entity/dto/request/JoinRequestDTO.java
@@ -16,6 +16,9 @@ public class JoinRequestDTO {
     private String password;
     private String checkPassword;
 
+    @NotBlank(message = "인증코드가 비어있습니다.")
+    private String verificationCode;
+
     public Member toEntity(){
         return Member.builder()
                 .email(this.email)

--- a/src/main/java/hackerton/wakeup/member/service/MemberService.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberService.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 public interface MemberService {
     boolean checkEmailDuplication(String email);
     void joinMember(JoinRequestDTO req);
+    void sendVerificationEmail(String email);
     Optional<Member> getMemberById(Long id);
     Optional<Member> getMemberByEmail(String email);
 }

--- a/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
@@ -1,5 +1,7 @@
 package hackerton.wakeup.member.service;
 
+import hackerton.wakeup.email.service.EmailSenderService;
+import hackerton.wakeup.email.service.EmailVerifyService;
 import hackerton.wakeup.member.entity.Member;
 import hackerton.wakeup.member.entity.dto.request.JoinRequestDTO;
 import hackerton.wakeup.member.repository.MemberRepository;
@@ -17,6 +19,8 @@ import java.util.Optional;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
+    private final EmailVerifyService emailVerifyService;
+    private final EmailSenderService emailSenderService;
 
     @Override
     public boolean checkEmailDuplication(String email) {

--- a/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
@@ -29,6 +29,11 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    public void sendVerificationEmail(String email) {
+
+    }
+
+    @Override
     public Optional<Member> getMemberById(Long id) {
         return memberRepository.findById(id);
     }

--- a/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
@@ -34,7 +34,8 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public void sendVerificationEmail(String email) {
-
+        String code = emailVerifyService.generateVerificationCode(email);
+        emailSenderService.sendVerificationCode(email, code);
     }
 
     @Override

--- a/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
@@ -29,6 +29,9 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public void joinMember(JoinRequestDTO req) {
+        if (!emailVerifyService.verifyCode(req.getEmail(), req.getPassword())) {
+            throw new RuntimeException("유효하지 않은 인증코드");
+        }
         memberRepository.save(req.toEntity());
     }
 

--- a/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
@@ -29,7 +29,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public void joinMember(JoinRequestDTO req) {
-        if (!emailVerifyService.verifyCode(req.getEmail(), req.getPassword())) {
+        if (emailVerifyService.verifyCode(req.getEmail(), req.getPassword())) {
             throw new RuntimeException("유효하지 않은 인증코드");
         }
         memberRepository.save(req.toEntity());


### PR DESCRIPTION
## 연관된 이슈

#9

## 작업 내용
이메일 인증 기능과 회원가입 기능을 연동하였습니다.
> 1. JoinRequestDTO 필드 추가
> > ![image](https://github.com/user-attachments/assets/978f5403-4717-4a5d-84a9-372795a9363a)
> > - 기존 필드에 인증번호를 받도록 verificationCode 필드를 추가했습니다.
>
> 2. MemberEntity Fix
> > ![image](https://github.com/user-attachments/assets/c1cc1679-bfc6-4c7a-b65a-9c000b7863fa)
> > - ID 필드는 자동으로 생성된다는 점에서 NotBlank 어노테이션을 제거했습니다.
> > - point 필드는 자료형이 int 이기에 NotBlank에서 NotNull로 변경하고 Min(0)을 추가했습니다.
>
> 3. MemberService 구현체 수정 및 확장
> > ![image](https://github.com/user-attachments/assets/9e9adc4a-6809-4315-8178-4096645bda00)
> > - 이메일 인증 기능을 참조하도록 했습니다.
> > - joinMember() method에 인증코드 검증 로직을 추가했습니다.
> > - 인증코드 이메일 전송을 위해 sendVerificationCode() method를 추가했습니다.
>
> 4. MemberController api 추가
> > ![image](https://github.com/user-attachments/assets/e4dc0d6a-50b6-4847-8ecb-2f0fd87085e1)
> > - /api/member/send-verification 경로에 POST 요청으로 이메일 전송 api를 구현했습니다.
>
> 5. 이메일 인증 중복요청 처리
> > ![image](https://github.com/user-attachments/assets/3d35c949-b455-472c-93ed-e40836a81627)
> > - 기존 인증코드를 발급하는 로직에선 일정 시간이 지나거나 회원가입이 성공하기 전까지 인증코드가 사라지지 않았습니다.
> > - 로컬메모리 과부하를 대비하여 이미 인증코드를 발급받은 이메일이라면 기존 코드가 삭제되도록 하였습니다.
> 
> 6. 테스트
> > 1. /send-verification api에 query로 email을 넘기며 요청
> > ![image](https://github.com/user-attachments/assets/a81b0ac0-ce2b-4e30-8634-534a2521d3b6)
> > 2. 이메일 전송
> > ![image](https://github.com/user-attachments/assets/f00fa629-4bf6-42fa-bd7d-6a829a859d06)
> > 3. /signup api에 회원가입 요청
> > ![image](https://github.com/user-attachments/assets/ceab6652-b5b4-4665-a27a-2e559079597b)
> > 4. 성공과 함께 DB에 저장
> > ![image](https://github.com/user-attachments/assets/22577d06-aa5e-4753-931d-d896f6c06149)
> > - 자동으로 생성된 DB가 순서가 꼬여있습니다..

## 기타(특이사항 등)
gmail에서 이전과 동일하다 판단된 이메일이 발송될 경우 본문을 일부 자르는 시스템이 있습니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/95026680-9c86-41b2-aa86-8973bb59be0f)