### PR TITLE
[FEATURE] 계정찾기 기능 구현

### DIFF
--- a/src/main/java/hackerton/wakeup/member/controller/MemberController.java
+++ b/src/main/java/hackerton/wakeup/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package hackerton.wakeup.member.controller;
 import hackerton.wakeup.common.security.JwtTokenUtil;
 import hackerton.wakeup.email.service.EmailVerifyService;
 import hackerton.wakeup.member.entity.Member;
+import hackerton.wakeup.member.entity.dto.request.ChangePasswordRequestDTO;
 import hackerton.wakeup.member.entity.dto.request.FindAccountRequestDTO;
 import hackerton.wakeup.member.entity.dto.request.JoinRequestDTO;
 import hackerton.wakeup.member.entity.dto.request.LoginRequestDTO;
@@ -57,6 +58,18 @@ public class MemberController {
             return new ResponseEntity<>("인증코드가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
         }
         return ResponseEntity.ok("인증성공");
+    }
+
+    @PutMapping("/change-password")
+    public ResponseEntity<String> changePassword(@Valid @RequestBody ChangePasswordRequestDTO req){
+        if (!memberService.checkEmailDuplication(req.getEmail())){
+            return new ResponseEntity<>("이메일이 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
+        }
+        if (!req.getPassword().equals(req.getCheckPassword())){
+            return new ResponseEntity<>("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+        }
+        memberService.changePassword(req);
+        return ResponseEntity.ok("비밀번호 변경 성공");
     }
 
     @PostMapping("/send-verification")

--- a/src/main/java/hackerton/wakeup/member/controller/MemberController.java
+++ b/src/main/java/hackerton/wakeup/member/controller/MemberController.java
@@ -49,7 +49,7 @@ public class MemberController {
         return ResponseEntity.ok(token);
     }
 
-    @PostMapping("/findAccount")
+    @PostMapping("/find-account")
     public ResponseEntity<String> findAccount(@Valid @RequestBody FindAccountRequestDTO req){
         if (!memberService.checkEmailDuplication(req.getEmail())){
             return new ResponseEntity<>("이메일이 존재하지 않습니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/hackerton/wakeup/member/controller/MemberController.java
+++ b/src/main/java/hackerton/wakeup/member/controller/MemberController.java
@@ -47,9 +47,6 @@ public class MemberController {
 
     @PostMapping("/send-verification")
     public ResponseEntity<String> sendVerification(@RequestParam("email") String email){
-        if (memberService.checkEmailDuplication(email)){
-            return new ResponseEntity<>("이미 존재하는 이메일입니다.", HttpStatus.BAD_REQUEST);
-        }
         memberService.sendVerificationEmail(email);
         return ResponseEntity.ok("인증코드가 이메일로 전송 되었습니다.");
     }

--- a/src/main/java/hackerton/wakeup/member/entity/dto/request/ChangePasswordRequestDTO.java
+++ b/src/main/java/hackerton/wakeup/member/entity/dto/request/ChangePasswordRequestDTO.java
@@ -11,4 +11,5 @@ import lombok.Setter;
 public class ChangePasswordRequestDTO {
     @NotBlank(message = "비밀번호가 비어있습니다.")
     private String password;
+    private String checkPassword;
 }

--- a/src/main/java/hackerton/wakeup/member/entity/dto/request/ChangePasswordRequestDTO.java
+++ b/src/main/java/hackerton/wakeup/member/entity/dto/request/ChangePasswordRequestDTO.java
@@ -1,0 +1,11 @@
+package hackerton.wakeup.member.entity.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChangePasswordRequestDTO {
+}

--- a/src/main/java/hackerton/wakeup/member/entity/dto/request/ChangePasswordRequestDTO.java
+++ b/src/main/java/hackerton/wakeup/member/entity/dto/request/ChangePasswordRequestDTO.java
@@ -1,5 +1,6 @@
 package hackerton.wakeup.member.entity.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,4 +9,6 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class ChangePasswordRequestDTO {
+    @NotBlank(message = "비밀번호가 비어있습니다.")
+    private String password;
 }

--- a/src/main/java/hackerton/wakeup/member/entity/dto/request/ChangePasswordRequestDTO.java
+++ b/src/main/java/hackerton/wakeup/member/entity/dto/request/ChangePasswordRequestDTO.java
@@ -9,6 +9,9 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class ChangePasswordRequestDTO {
+    @NotBlank
+    private String email;
+
     @NotBlank(message = "비밀번호가 비어있습니다.")
     private String password;
     private String checkPassword;

--- a/src/main/java/hackerton/wakeup/member/entity/dto/request/FindAccountRequestDTO.java
+++ b/src/main/java/hackerton/wakeup/member/entity/dto/request/FindAccountRequestDTO.java
@@ -11,4 +11,7 @@ import lombok.Setter;
 public class FindAccountRequestDTO {
     @NotBlank(message = "이메일이 비어있습니다.")
     private String email;
+
+    @NotBlank(message = "인증번호가 비어있습니다.")
+    private String verificationCode;
 }

--- a/src/main/java/hackerton/wakeup/member/entity/dto/request/FindAccountRequestDTO.java
+++ b/src/main/java/hackerton/wakeup/member/entity/dto/request/FindAccountRequestDTO.java
@@ -1,5 +1,6 @@
 package hackerton.wakeup.member.entity.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,4 +9,6 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class FindAccountRequestDTO {
+    @NotBlank(message = "이메일이 비어있습니다.")
+    private String email;
 }

--- a/src/main/java/hackerton/wakeup/member/entity/dto/request/FindAccountRequestDTO.java
+++ b/src/main/java/hackerton/wakeup/member/entity/dto/request/FindAccountRequestDTO.java
@@ -1,0 +1,11 @@
+package hackerton.wakeup.member.entity.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class FindAccountRequestDTO {
+}

--- a/src/main/java/hackerton/wakeup/member/service/MemberService.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package hackerton.wakeup.member.service;
 
 import hackerton.wakeup.member.entity.Member;
+import hackerton.wakeup.member.entity.dto.request.ChangePasswordRequestDTO;
 import hackerton.wakeup.member.entity.dto.request.JoinRequestDTO;
 import hackerton.wakeup.member.entity.dto.request.LoginRequestDTO;
 
@@ -10,6 +11,7 @@ public interface MemberService {
     boolean checkEmailDuplication(String email);
     void joinMember(JoinRequestDTO req);
     Member loginMember(LoginRequestDTO req);
+    void changePassword(ChangePasswordRequestDTO req);
     void sendVerificationEmail(String email);
     Optional<Member> getMemberById(Long id);
     Optional<Member> getMemberByEmail(String email);

--- a/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
@@ -58,7 +58,13 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public void changePassword(ChangePasswordRequestDTO req) {
-
+        Member member = memberRepository.findByEmail(req.getEmail()).get();
+        memberRepository.save(Member.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .password(passwordEncoder.encode(req.getPassword()))
+                .point(member.getPoint())
+                .build());
     }
 
     @Override

--- a/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/member/service/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package hackerton.wakeup.member.service;
 import hackerton.wakeup.email.service.EmailSenderService;
 import hackerton.wakeup.email.service.EmailVerifyService;
 import hackerton.wakeup.member.entity.Member;
+import hackerton.wakeup.member.entity.dto.request.ChangePasswordRequestDTO;
 import hackerton.wakeup.member.entity.dto.request.JoinRequestDTO;
 import hackerton.wakeup.member.entity.dto.request.LoginRequestDTO;
 import hackerton.wakeup.member.repository.MemberRepository;
@@ -53,6 +54,11 @@ public class MemberServiceImpl implements MemberService {
 
 
         return member;
+    }
+
+    @Override
+    public void changePassword(ChangePasswordRequestDTO req) {
+
     }
 
     @Override


### PR DESCRIPTION
## 연관된 이슈

#21

## 작업 내용
> 계정 찾기 기능을 구현했습니다.
>
> 1. 이메일 인증 DTO 생성
> > ![image](https://github.com/user-attachments/assets/6c7f9bbe-76bd-4677-8f46-11fbc3baa972)
> > - 계정 찾기에서 이메일 인증 부분에 사용될 DTO입니다.
>
> 2. 이메일 인증 Controller 작성
> > ![image](https://github.com/user-attachments/assets/0718ed39-4c5a-444b-b543-a3721bde55e9)
> > - 존재하지 않는 이메일이거나 인증코드가 일치하지 않으면 인증되지 않습니다.
> > - 인증 성공하면 200 OK를 반환합니다.
>
> 3. 비밀번호 변경 DTO 생성
> > ![image](https://github.com/user-attachments/assets/5e708097-58b1-40d2-b952-1fea5624086f)
> > - 비밀번호 변경에 사용될 DTO입니다.
> > - 클라이언트에서 앞서 인증된 이메일을 같이 전송해줍니다.
>
> 4. 비밀번호 변경 Controller 작성
> > ![image](https://github.com/user-attachments/assets/7b183430-3ef7-4c40-b8fe-0a9ffe09efb0)
> > - 존재하지 않는 이메일이거나 비밀번호가 일치하지 않으면 변경되지 않습니다.
> > - 만약 제대로 된 요청이라면 비밀번호를 변경하고 200 OK를 반환합니다.
>
> 5. 비밀번호 변경 Service 작성
> > ![image](https://github.com/user-attachments/assets/1e6960d1-ff8f-42a8-bc3b-6c953d08e42b)
> > - 입력받은 비밀번호 기반으로 기존 DB에서 비밀번호를 암호화하여 변경합니다.
>
> 6. Test
> > 1. 회원가입으로 DB에 회원을 등록합니다. 로그인을 통해 기존 비밀번호가 1234임을 알 수 있습니다.
> > ![image](https://github.com/user-attachments/assets/4fb0a24e-70e8-4c96-9abf-b0a674949f7b)
> > ![image](https://github.com/user-attachments/assets/3de6d2b6-2a3b-4542-8ce1-071922d54fee)
> > ![image](https://github.com/user-attachments/assets/fcb2b89b-f0f3-4d7f-8e84-a6cfba525199)
> > 2. 이메일 인증은 회원가입과 비슷하게 이뤄집니다. 이메일과 인증번호로 요청합니다.
> > ![image](https://github.com/user-attachments/assets/7428816d-b7c8-493a-a724-6b5ea1f9117d)
> > 3. 비밀번호 변경을 요청하여 비밀번호를 변경합니다. 로그인을 통해 변경 여부를 확인할 수 있습니다.
> > ![image](https://github.com/user-attachments/assets/f537004f-d6fe-46a9-aaf6-7b92bf2874aa)
> > ![image](https://github.com/user-attachments/assets/6a1b174f-27cf-4b0c-a9e6-e595d03f2dca)
> > ![image](https://github.com/user-attachments/assets/6d11af1d-1e97-47c3-8a30-f2492c701395)

## 기타(특이사항 등)
- 인증 성공시 200 OK를 반환하고 클라이언트에서 이메일과 함께 변경할 비밀번호를 보내도록 작성하였습니다.

## 💬리뷰 요구사항(선택)

> - 인증 부분을 findAccount로 이름을 지정하였는데 다른 이름으로 변경하는 편이 좋을까요?