### PR TITLE
[FEATURE] 자기소개 기능 개발

### DIFF
--- a/src/main/java/hackerton/wakeup/member/controller/MemberController.java
+++ b/src/main/java/hackerton/wakeup/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import hackerton.wakeup.member.entity.dto.request.LoginRequestDTO;
 import hackerton.wakeup.member.entity.dto.response.JwtTokenResponseDTO;
 import hackerton.wakeup.member.entity.dto.response.MyInfoResponseDTO;
 import hackerton.wakeup.member.service.MemberService;
+import hackerton.wakeup.memberInfo.service.MemberInfoService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,6 +27,7 @@ public class MemberController {
     private final MemberService memberService;
     private final EmailVerifyService emailVerifyService;
     private final CharacterService characterService;
+    private final MemberInfoService memberInfoService;
     @Value("${spring.jwt.secretKey}")
     private String secretKey;
     @Value("${spring.jwt.expirationTime}")
@@ -42,6 +44,7 @@ public class MemberController {
         }
         memberService.joinMember(req);
         characterService.initCharacter(memberService.getMemberByEmail(req.getEmail()).get());
+        memberInfoService.initMemberInfo(memberService.getMemberByEmail(req.getEmail()).get());
         String token = JwtTokenUtil.createToken(req.getEmail(), secretKey, Long.parseLong(expirationTime));
         return ResponseEntity.ok(new JwtTokenResponseDTO(token, expirationTime));
     }

--- a/src/main/java/hackerton/wakeup/memberInfo/controller/MemberInfoController.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/controller/MemberInfoController.java
@@ -22,7 +22,7 @@ public class MemberInfoController {
     @PostMapping("/set-nickname")
     public ResponseEntity<String> setNickname(@Valid @RequestBody SetNicknameRequestDTO req, Authentication auth){
         Member member = memberService.getMemberByEmail(auth.getName()).get();
-        String resultNickname = memberInfoService.settingNickname(member, req.getNickname());
+        String resultNickname = memberInfoService.settingNickname(member, req);
         return ResponseEntity.ok("닉네임 설정 성공: " + resultNickname);
     }
 

--- a/src/main/java/hackerton/wakeup/memberInfo/controller/MemberInfoController.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/controller/MemberInfoController.java
@@ -20,14 +20,14 @@ public class MemberInfoController {
     private final MemberInfoService memberInfoService;
     private final MemberService memberService;
 
-    @PostMapping("/set-nickname")
+    @PutMapping("/set-nickname")
     public ResponseEntity<String> setNickname(@Valid @RequestBody SetNicknameRequestDTO req, Authentication auth){
         Member member = memberService.getMemberByEmail(auth.getName()).get();
         String resultNickname = memberInfoService.settingNickname(member, req);
         return ResponseEntity.ok("닉네임 설정 성공: " + resultNickname);
     }
 
-    @PostMapping("/set-introduction")
+    @PutMapping("/set-introduction")
     public ResponseEntity<String> setIntroduction(@Valid @RequestBody SetIntroductionRequestDTO req, Authentication auth){
         Member member = memberService.getMemberByEmail(auth.getName()).get();
         String resultIntroduction = memberInfoService.settingIntroduction(member, req);

--- a/src/main/java/hackerton/wakeup/memberInfo/controller/MemberInfoController.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/controller/MemberInfoController.java
@@ -3,6 +3,7 @@ package hackerton.wakeup.memberInfo.controller;
 import hackerton.wakeup.member.entity.Member;
 import hackerton.wakeup.member.service.MemberService;
 import hackerton.wakeup.memberInfo.entity.MemberInfo;
+import hackerton.wakeup.memberInfo.entity.dto.request.SetIntroductionRequestDTO;
 import hackerton.wakeup.memberInfo.entity.dto.request.SetNicknameRequestDTO;
 import hackerton.wakeup.memberInfo.service.MemberInfoService;
 import jakarta.validation.Valid;
@@ -24,6 +25,13 @@ public class MemberInfoController {
         Member member = memberService.getMemberByEmail(auth.getName()).get();
         String resultNickname = memberInfoService.settingNickname(member, req);
         return ResponseEntity.ok("닉네임 설정 성공: " + resultNickname);
+    }
+
+    @PostMapping("/set-introduction")
+    public ResponseEntity<String> setIntroduction(@Valid @RequestBody SetIntroductionRequestDTO req, Authentication auth){
+        Member member = memberService.getMemberByEmail(auth.getName()).get();
+        String resultIntroduction = memberInfoService.settingIntroduction(member, req);
+        return ResponseEntity.ok("소개 설정 성공: " + resultIntroduction);
     }
 
     @GetMapping("/info")

--- a/src/main/java/hackerton/wakeup/memberInfo/entity/MemberInfo.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/entity/MemberInfo.java
@@ -30,4 +30,6 @@ public class MemberInfo {
 
     @NotBlank
     private String tag;
+
+    private String introduction;
 }

--- a/src/main/java/hackerton/wakeup/memberInfo/entity/dto/MemberInfoDtoConverter.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/entity/dto/MemberInfoDtoConverter.java
@@ -1,0 +1,4 @@
+package hackerton.wakeup.memberInfo.entity.dto;
+
+public class MemberInfoDtoConverter {
+}

--- a/src/main/java/hackerton/wakeup/memberInfo/entity/dto/MemberInfoDtoConverter.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/entity/dto/MemberInfoDtoConverter.java
@@ -1,4 +1,16 @@
 package hackerton.wakeup.memberInfo.entity.dto;
 
+import hackerton.wakeup.memberInfo.entity.MemberInfo;
+import hackerton.wakeup.memberInfo.entity.dto.request.SetIntroductionRequestDTO;
+
 public class MemberInfoDtoConverter {
+
+    public static MemberInfo setIntroductionRequestConverter(MemberInfo memberInfo, SetIntroductionRequestDTO req){
+        return MemberInfo.builder()
+                .id(memberInfo.getId())
+                .nickname(memberInfo.getNickname())
+                .tag(memberInfo.getTag())
+                .introduction(req.getIntroduction())
+                .build();
+    }
 }

--- a/src/main/java/hackerton/wakeup/memberInfo/entity/dto/MemberInfoDtoConverter.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/entity/dto/MemberInfoDtoConverter.java
@@ -2,15 +2,27 @@ package hackerton.wakeup.memberInfo.entity.dto;
 
 import hackerton.wakeup.memberInfo.entity.MemberInfo;
 import hackerton.wakeup.memberInfo.entity.dto.request.SetIntroductionRequestDTO;
+import hackerton.wakeup.memberInfo.entity.dto.request.SetNicknameRequestDTO;
 
 public class MemberInfoDtoConverter {
 
     public static MemberInfo setIntroductionRequestConverter(MemberInfo memberInfo, SetIntroductionRequestDTO req){
         return MemberInfo.builder()
                 .id(memberInfo.getId())
+                .member(memberInfo.getMember())
                 .nickname(memberInfo.getNickname())
                 .tag(memberInfo.getTag())
                 .introduction(req.getIntroduction())
+                .build();
+    }
+
+    public static MemberInfo setNicknameRequestConverter(MemberInfo memberInfo, SetNicknameRequestDTO req, String tag){
+        return MemberInfo.builder()
+                .id(memberInfo.getId())
+                .member(memberInfo.getMember())
+                .nickname(req.getNickname())
+                .tag(tag)
+                .introduction(memberInfo.getIntroduction())
                 .build();
     }
 }

--- a/src/main/java/hackerton/wakeup/memberInfo/entity/dto/request/SetIntroductionRequestDTO.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/entity/dto/request/SetIntroductionRequestDTO.java
@@ -1,0 +1,9 @@
+package hackerton.wakeup.memberInfo.entity.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SetIntroductionRequestDTO {
+}

--- a/src/main/java/hackerton/wakeup/memberInfo/entity/dto/request/SetIntroductionRequestDTO.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/entity/dto/request/SetIntroductionRequestDTO.java
@@ -1,9 +1,12 @@
 package hackerton.wakeup.memberInfo.entity.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class SetIntroductionRequestDTO {
+    @NotBlank(message = "자기소개는 최소 한 글자 이상 입력해야합니다.")
+    private String introduction;
 }

--- a/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoService.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoService.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 public interface MemberInfoService {
     boolean checkNicknameAndTagDuplication(String nickname, String tag);
+    void initMemberInfo(Member member);
     String settingNickname(Member member, SetNicknameRequestDTO req);
     String settingIntroduction(Member member, SetIntroductionRequestDTO req);
     MemberInfo findById(MemberInfoId id);

--- a/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoService.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoService.java
@@ -3,12 +3,13 @@ package hackerton.wakeup.memberInfo.service;
 import hackerton.wakeup.member.entity.Member;
 import hackerton.wakeup.memberInfo.entity.MemberInfo;
 import hackerton.wakeup.memberInfo.entity.MemberInfoId;
+import hackerton.wakeup.memberInfo.entity.dto.request.SetNicknameRequestDTO;
 
 import java.util.Optional;
 
 public interface MemberInfoService {
     boolean checkNicknameAndTagDuplication(String nickname, String tag);
-    String settingNickname(Member member, String nickname);
+    String settingNickname(Member member, SetNicknameRequestDTO req);
     MemberInfo findById(MemberInfoId id);
     MemberInfo findByMemberId(Long member_id);
 }

--- a/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoService.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoService.java
@@ -3,6 +3,7 @@ package hackerton.wakeup.memberInfo.service;
 import hackerton.wakeup.member.entity.Member;
 import hackerton.wakeup.memberInfo.entity.MemberInfo;
 import hackerton.wakeup.memberInfo.entity.MemberInfoId;
+import hackerton.wakeup.memberInfo.entity.dto.request.SetIntroductionRequestDTO;
 import hackerton.wakeup.memberInfo.entity.dto.request.SetNicknameRequestDTO;
 
 import java.util.Optional;
@@ -10,6 +11,7 @@ import java.util.Optional;
 public interface MemberInfoService {
     boolean checkNicknameAndTagDuplication(String nickname, String tag);
     String settingNickname(Member member, SetNicknameRequestDTO req);
+    String settingIntroduction(Member member, SetIntroductionRequestDTO req);
     MemberInfo findById(MemberInfoId id);
     MemberInfo findByMemberId(Long member_id);
 }

--- a/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoServiceImpl.java
@@ -4,6 +4,7 @@ import hackerton.wakeup.member.entity.Member;
 import hackerton.wakeup.memberInfo.entity.MemberInfo;
 import hackerton.wakeup.memberInfo.entity.MemberInfoId;
 import hackerton.wakeup.memberInfo.entity.dto.MemberInfoDtoConverter;
+import hackerton.wakeup.memberInfo.entity.dto.request.SetIntroductionRequestDTO;
 import hackerton.wakeup.memberInfo.entity.dto.request.SetNicknameRequestDTO;
 import hackerton.wakeup.memberInfo.repository.MemberInfoRepository;
 import lombok.RequiredArgsConstructor;
@@ -46,6 +47,11 @@ public class MemberInfoServiceImpl implements MemberInfoService{
             memberInfoRepository.save(MemberInfoDtoConverter.setNicknameRequestConverter(findMemberInfo, req, tag));
         }
         return req.getNickname() + "#" + tag;
+    }
+
+    @Override
+    public String settingIntroduction(Member member, SetIntroductionRequestDTO req) {
+        return "";
     }
 
     @Override

--- a/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoServiceImpl.java
@@ -52,7 +52,7 @@ public class MemberInfoServiceImpl implements MemberInfoService{
     @Override
     public String settingIntroduction(Member member, SetIntroductionRequestDTO req) {
         memberInfoRepository.save(MemberInfoDtoConverter.setIntroductionRequestConverter(member.getMemberInfo(), req));
-        return "한 줄 소개 설정 성공: " + req.getIntroduction();
+        return req.getIntroduction();
     }
 
     @Override

--- a/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoServiceImpl.java
@@ -28,24 +28,28 @@ public class MemberInfoServiceImpl implements MemberInfoService{
     }
 
     @Override
+    public void initMemberInfo(Member member) {
+        String tag = "0000";
+        while (memberInfoRepository.existsByNicknameAndTag("사용자", tag)){
+            tag = RandomStringUtils.randomNumeric(4);
+        }
+        MemberInfoId memberInfoId = MemberInfoId.builder().id(member.getId()).member(member.getId()).build();
+        memberInfoRepository.save(MemberInfo.builder().id(memberInfoId)
+                .member(member)
+                .nickname("사용자")
+                .tag(tag)
+                .introduction(null).build());
+    }
+
+    @Override
     public String settingNickname(Member member, SetNicknameRequestDTO req) {
         String tag = "0000";
         while (memberInfoRepository.existsByNicknameAndTag(req.getNickname(), tag)){
             tag = RandomStringUtils.randomNumeric(4);
         }
         MemberInfoId memberInfoId = MemberInfoId.builder().id(member.getId()).member(member.getId()).build();
-        MemberInfo findMemberInfo = memberInfoRepository.findById(memberInfoId).orElse(null);
-        if (findMemberInfo == null){
-            memberInfoRepository.save(MemberInfo.builder()
-                    .id(memberInfoId)
-                    .member(member)
-                    .nickname(req.getNickname())
-                    .tag(tag)
-                    .introduction(null).build());
-        }
-        else {
-            memberInfoRepository.save(MemberInfoDtoConverter.setNicknameRequestConverter(findMemberInfo, req, tag));
-        }
+        MemberInfo findMemberInfo = memberInfoRepository.findById(memberInfoId).get();
+        memberInfoRepository.save(MemberInfoDtoConverter.setNicknameRequestConverter(findMemberInfo, req, tag));
         return req.getNickname() + "#" + tag;
     }
 

--- a/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoServiceImpl.java
@@ -3,6 +3,8 @@ package hackerton.wakeup.memberInfo.service;
 import hackerton.wakeup.member.entity.Member;
 import hackerton.wakeup.memberInfo.entity.MemberInfo;
 import hackerton.wakeup.memberInfo.entity.MemberInfoId;
+import hackerton.wakeup.memberInfo.entity.dto.MemberInfoDtoConverter;
+import hackerton.wakeup.memberInfo.entity.dto.request.SetNicknameRequestDTO;
 import hackerton.wakeup.memberInfo.repository.MemberInfoRepository;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -25,19 +27,25 @@ public class MemberInfoServiceImpl implements MemberInfoService{
     }
 
     @Override
-    public String settingNickname(Member member, String nickname) {
+    public String settingNickname(Member member, SetNicknameRequestDTO req) {
         String tag = "0000";
-        while (memberInfoRepository.existsByNicknameAndTag(nickname, tag)){
+        while (memberInfoRepository.existsByNicknameAndTag(req.getNickname(), tag)){
             tag = RandomStringUtils.randomNumeric(4);
         }
         MemberInfoId memberInfoId = MemberInfoId.builder().id(member.getId()).member(member.getId()).build();
-        memberInfoRepository.save(MemberInfo.builder()
-                .id(memberInfoId)
-                .member(member)
-                .nickname(nickname)
-                .tag(tag)
-                .build());
-        return nickname + "#" + tag;
+        MemberInfo findMemberInfo = memberInfoRepository.findById(memberInfoId).orElse(null);
+        if (findMemberInfo == null){
+            memberInfoRepository.save(MemberInfo.builder()
+                    .id(memberInfoId)
+                    .member(member)
+                    .nickname(req.getNickname())
+                    .tag(tag)
+                    .introduction(null).build());
+        }
+        else {
+            memberInfoRepository.save(MemberInfoDtoConverter.setNicknameRequestConverter(findMemberInfo, req, tag));
+        }
+        return req.getNickname() + "#" + tag;
     }
 
     @Override

--- a/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoServiceImpl.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/service/MemberInfoServiceImpl.java
@@ -51,7 +51,8 @@ public class MemberInfoServiceImpl implements MemberInfoService{
 
     @Override
     public String settingIntroduction(Member member, SetIntroductionRequestDTO req) {
-        return "";
+        memberInfoRepository.save(MemberInfoDtoConverter.setIntroductionRequestConverter(member.getMemberInfo(), req));
+        return "한 줄 소개 설정 성공: " + req.getIntroduction();
     }
 
     @Override


### PR DESCRIPTION
## 연관된 이슈

#35

## 작업 내용
> 자기소개 기능을 개발하고 MemberInfo 연관 DTO의 converter 클래스 개발
>
> 1. MemberInfo Entity
> > ![image](https://github.com/user-attachments/assets/2af5300e-4011-4743-a8f4-b2175ab54632)
> > - introduction 필드를 추가했습니다.
>
> 2. DTO
> > ![image](https://github.com/user-attachments/assets/4f032ad2-9a70-4d9d-9b8c-2e68b04e6f60)
> > - 자기소개 설정 DTO입니다.
>
> 3. Converter
> > ![image](https://github.com/user-attachments/assets/a5707d42-1d94-4ec6-8d26-24f8a33f05c0)
> > - setIntroductionRequestConverter() method는 자기소개 요청을 저장하기 위해 MemberInfo로 빌드하는 method 입니다.
> > - setNicknameRequestConverter() method는 닉네임을 설정하고 저장하기 위해 MemberInfo로 빌드하는 method 입니다.
>
> 4. Service
> > ![image](https://github.com/user-attachments/assets/25339318-2f73-494d-8da6-6da631c4429a)
> > - 기존에 닉네임 설정시 바뀌는 형식에서 회원가입시 먼저 테이블을 생성하도록 변경하였습니다.
> > - 닉네임 설정시 Converter를 사용하도록 변경하였습니다.
> > - settingIntroduction() method로 자기소개를 변경할 수 있도록 작성하였습니다.
>
> 5. Controller
> > ![image](https://github.com/user-attachments/assets/1a063e78-f23b-4691-9df0-dce55c6d4e88)
> > - 기존에 닉네임 변경 api의 요청을 PUT으로 변경하였습니다.
> > - /set-introduction Path에 PUT 요청으로 자기소개 변경 method인 setIntroduction()을 작성했습니다.
>
> 6. Test
> > 1. 회원가입시 생성되는 MemberInfo 테이블 확인
> > ![image](https://github.com/user-attachments/assets/f66e4d14-d535-4510-ac76-918fe4d17130)
> > 2. 닉네임 설정 후 정보 조회
> > ![image](https://github.com/user-attachments/assets/b62820f6-dc55-4e0f-a275-36f6edf82a02)
> > ![image](https://github.com/user-attachments/assets/00ec9d57-263a-4202-89cb-746acdadaa94)
> > 3. 자기소개 설정 후 정보 조회
> > ![image](https://github.com/user-attachments/assets/078a3c45-2121-43be-9a80-24cb2eebd499)
> > ![image](https://github.com/user-attachments/assets/05ce5e7d-4966-4ce9-9bb8-021bf5d3c7a9)
> > 4. DB
> > ![image](https://github.com/user-attachments/assets/e26dc22d-5703-46f1-9371-4592dab315b3)