### PR TITLE
[FEATURE] 스트레칭 성공 관련 스탯 api 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,7 @@ gradle-app.setting
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,intellij
 
 application.yml
+application-dev.yml
+application-local.yml
+application-prod.yml
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-    plugins {
+plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.5'
@@ -29,27 +29,40 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-mail'
-    implementation 'org.apache.commons:commons-lang3:3.0'
-    implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     implementation 'org.springframework.boot:spring-boot-starter-test'
 
-    implementation 'javax.xml.bind:jaxb-api:2.3.1'
-    implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.1'
-
     //h2 db
     runtimeOnly 'com.h2database:h2'
 
-    //lombok
+    // postgresql
+//    implementation 'org.postgresql:postgresql'
+
+    // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // 메일 인증
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // JWT
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.1'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/hackerton/wakeup/achievement/Repository/AchievementRepository.java
+++ b/src/main/java/hackerton/wakeup/achievement/Repository/AchievementRepository.java
@@ -1,0 +1,19 @@
+package hackerton.wakeup.achievement.Repository;
+
+import hackerton.wakeup.achievement.domain.Achievement;
+import hackerton.wakeup.member.entity.Member;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface AchievementRepository extends JpaRepository<Achievement, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT a FROM Achievement a WHERE a.member = :member AND a.date = :date")
+    Optional<Achievement> findByMemberAndDateWithLock(@Param("member") Member member, @Param("date") String date);
+    Optional<Achievement> findByMemberAndDate(Member member, String date);
+}

--- a/src/main/java/hackerton/wakeup/achievement/controller/AchievementController.java
+++ b/src/main/java/hackerton/wakeup/achievement/controller/AchievementController.java
@@ -1,0 +1,26 @@
+package hackerton.wakeup.achievement.controller;
+
+import hackerton.wakeup.achievement.service.AchievementService;
+import hackerton.wakeup.achievement.service.dto.AchievementRequest;
+import hackerton.wakeup.achievement.service.dto.GetAchievementResponse;
+import hackerton.wakeup.achievement.service.dto.GetGoalResponse;
+import hackerton.wakeup.alarm.service.dto.AlarmPostRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/achievement")
+public class AchievementController {
+    private final AchievementService achievementService;
+
+    @PostMapping("")
+    public ResponseEntity<Map<String, Map<String, GetAchievementResponse>>> getAchievement(
+            @RequestBody AchievementRequest achievementRequest
+    ) {
+        return ResponseEntity.ok(achievementService.getAchievement(achievementRequest.getNickname(), achievementRequest.getTag()));
+    }
+}

--- a/src/main/java/hackerton/wakeup/achievement/controller/AchievementController.java
+++ b/src/main/java/hackerton/wakeup/achievement/controller/AchievementController.java
@@ -23,4 +23,11 @@ public class AchievementController {
     ) {
         return ResponseEntity.ok(achievementService.getAchievement(achievementRequest.getNickname(), achievementRequest.getTag()));
     }
+
+    @PostMapping("/goal")
+    public ResponseEntity<GetGoalResponse> getGoal(
+            @RequestBody AchievementRequest achievementRequest
+    ) {
+        return ResponseEntity.ok(achievementService.getGoal(achievementRequest.getNickname(), achievementRequest.getTag()));
+    }
 }

--- a/src/main/java/hackerton/wakeup/achievement/domain/Achievement.java
+++ b/src/main/java/hackerton/wakeup/achievement/domain/Achievement.java
@@ -1,0 +1,33 @@
+package hackerton.wakeup.achievement.domain;
+
+import hackerton.wakeup.common.domain.BaseEntity;
+import hackerton.wakeup.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder(toBuilder = true)
+@EqualsAndHashCode(of = "id", callSuper = false)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Achievement extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private Integer success;
+
+    @Column
+    private Integer failure;
+
+    // yyMMdd(ex-240101)
+    @Column
+    private String date;
+
+    @OneToOne
+    @JoinColumn(name = "MEMBER_ID")
+    private Member member;
+}

--- a/src/main/java/hackerton/wakeup/achievement/service/AchievementService.java
+++ b/src/main/java/hackerton/wakeup/achievement/service/AchievementService.java
@@ -1,0 +1,75 @@
+package hackerton.wakeup.achievement.service;
+
+import hackerton.wakeup.achievement.Repository.AchievementRepository;
+import hackerton.wakeup.achievement.domain.Achievement;
+import hackerton.wakeup.achievement.service.dto.GetAchievementResponse;
+import hackerton.wakeup.achievement.service.dto.GetGoalResponse;
+import hackerton.wakeup.character.entity.Character;
+import hackerton.wakeup.character.repository.CharacterRepository;
+import hackerton.wakeup.member.entity.Member;
+import hackerton.wakeup.memberInfo.entity.MemberInfo;
+import hackerton.wakeup.memberInfo.repository.MemberInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AchievementService {
+    private final MemberInfoRepository memberInfoRepository;
+    private final AchievementRepository achievementRepository;
+    private final CharacterRepository characterRepository;
+
+    @Transactional
+    public Map<String, Map<String, GetAchievementResponse>> getAchievement(String nickname, String tag) {
+        MemberInfo memberInfo = memberInfoRepository.findByNicknameAndTag(nickname, tag).get();
+        LocalDateTime now = LocalDateTime.now();
+
+        // 'yyMMdd' 형식으로 변환하기 위한 포맷터를 생성
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyMMdd");
+
+        // 앞 7일과 뒤 7일 간의 날짜와 업적 정보를 맵에 저장
+        Map<String, Map<String, GetAchievementResponse>> lastWeekDateMap = new HashMap<>();
+        Map<String, Map<String, GetAchievementResponse>> nextWeekDateMap = new HashMap<>();
+
+        // 앞 14일
+        populateDateMap(lastWeekDateMap, memberInfo, now, -14, 0, formatter);
+
+        // 뒤 7일
+        populateDateMap(nextWeekDateMap, memberInfo, now, 1, 7, formatter);
+
+        // 결합하여 반환
+        Map<String, Map<String, GetAchievementResponse>> combinedMap = new HashMap<>();
+        combinedMap.putAll(lastWeekDateMap);
+        combinedMap.putAll(nextWeekDateMap);
+
+        return combinedMap;
+    }
+
+    private void populateDateMap(Map<String, Map<String, GetAchievementResponse>> dateMap, MemberInfo memberInfo, LocalDateTime now, int startOffset, int endOffset, DateTimeFormatter formatter) {
+        for (int i = startOffset; i <= endOffset; i++) {
+            LocalDate date = now.toLocalDate().plusDays(i);
+            String formatted = date.format(formatter);
+            DayOfWeek dayOfWeek = date.getDayOfWeek();
+            Achievement achievement = achievementRepository.findByMemberAndDate(memberInfo.getMember(), formatted)
+                    .orElse(
+                        Achievement.builder()
+                                .success(0)
+                                .failure(0)
+                                .date(formatted)
+                                .member(memberInfo.getMember())
+                                .build()
+                );
+            GetAchievementResponse getAchievementResponse = new GetAchievementResponse(achievement);
+            dateMap.put(formatted, Map.of(dayOfWeek.toString(), getAchievementResponse));
+        }
+    }
+
+}

--- a/src/main/java/hackerton/wakeup/achievement/service/AchievementService.java
+++ b/src/main/java/hackerton/wakeup/achievement/service/AchievementService.java
@@ -71,5 +71,22 @@ public class AchievementService {
             dateMap.put(formatted, Map.of(dayOfWeek.toString(), getAchievementResponse));
         }
     }
+    public GetGoalResponse getGoal(String nickname, String tag) {
+        MemberInfo memberInfo = memberInfoRepository.findByNicknameAndTag(nickname, tag).get();
+        Member member = memberInfo.getMember();
+        Character character = characterRepository.findByIdMember(member.getId()).get();
+
+        Long requiredExp = character.getLevel() * 5L;
+        Long currentExp = character.getExp();
+
+        // 비율 계산 및 백분율 계산
+        float ratio = (float) currentExp / (float) requiredExp * 100;
+
+        // 소수점 둘째 자리까지 반올림
+        float percentage = Math.round(ratio * 100) / 100.0f;
+
+        // Dto 생성 및 반환
+        return new GetGoalResponse(member.getId(), requiredExp, currentExp, percentage);
+    }
 
 }

--- a/src/main/java/hackerton/wakeup/achievement/service/dto/AchievementRequest.java
+++ b/src/main/java/hackerton/wakeup/achievement/service/dto/AchievementRequest.java
@@ -1,0 +1,9 @@
+package hackerton.wakeup.achievement.service.dto;
+
+import lombok.Data;
+
+@Data
+public class AchievementRequest {
+    private String nickname;
+    private String tag;
+}

--- a/src/main/java/hackerton/wakeup/achievement/service/dto/GetAchievementResponse.java
+++ b/src/main/java/hackerton/wakeup/achievement/service/dto/GetAchievementResponse.java
@@ -1,0 +1,21 @@
+package hackerton.wakeup.achievement.service.dto;
+
+import hackerton.wakeup.achievement.domain.Achievement;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class GetAchievementResponse {
+    private Long id;
+    private Integer success;
+    private Integer failure;
+    private String date;
+
+    public GetAchievementResponse (Achievement achievement) {
+        this.id = achievement.getId();
+        this.success = achievement.getSuccess();
+        this.failure = achievement.getFailure();
+        this.date = achievement.getDate();
+    }
+}

--- a/src/main/java/hackerton/wakeup/achievement/service/dto/GetGoalResponse.java
+++ b/src/main/java/hackerton/wakeup/achievement/service/dto/GetGoalResponse.java
@@ -1,0 +1,22 @@
+package hackerton.wakeup.achievement.service.dto;
+
+import hackerton.wakeup.character.entity.Character;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.text.DecimalFormat;
+
+@Data
+@NoArgsConstructor
+public class GetGoalResponse {
+    private Long memberId;
+    private Long requiredExp;
+    private Long currentExp;
+    private Float currentExpPerRequiredExp;
+    public GetGoalResponse(Long memberId, Long requiredExp, Long currentExp, Float currentExpPerRequiredExp) {
+        this.memberId = memberId;
+        this.requiredExp = requiredExp;
+        this.currentExp = currentExp;
+        this.currentExpPerRequiredExp = currentExpPerRequiredExp;
+    }
+}

--- a/src/main/java/hackerton/wakeup/alarm/controller/AlarmController.java
+++ b/src/main/java/hackerton/wakeup/alarm/controller/AlarmController.java
@@ -1,0 +1,27 @@
+package hackerton.wakeup.alarm.controller;
+
+import hackerton.wakeup.alarm.service.AlarmService;
+import hackerton.wakeup.alarm.service.dto.AlarmPostRequest;
+import hackerton.wakeup.alarm.service.dto.AlarmPostResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/alarm")
+public class AlarmController {
+    private final AlarmService alarmService;
+
+    @PostMapping("")
+    public ResponseEntity<AlarmPostResponse> postAlarm(@RequestBody AlarmPostRequest alarmPostRequest) {
+        return ResponseEntity.ok(alarmService.postAlarm(
+                alarmPostRequest.getNickname(),
+                alarmPostRequest.getTag(),
+                alarmPostRequest.getIsSuccess()
+        ));
+    }
+}

--- a/src/main/java/hackerton/wakeup/alarm/service/AlarmService.java
+++ b/src/main/java/hackerton/wakeup/alarm/service/AlarmService.java
@@ -1,0 +1,139 @@
+package hackerton.wakeup.alarm.service;
+
+import hackerton.wakeup.achievement.Repository.AchievementRepository;
+import hackerton.wakeup.achievement.domain.Achievement;
+import hackerton.wakeup.alarm.service.dto.AlarmPostResponse;
+import hackerton.wakeup.character.entity.Character;
+import hackerton.wakeup.character.repository.CharacterRepository;
+import hackerton.wakeup.member.entity.Member;
+import hackerton.wakeup.member.repository.MemberRepository;
+import hackerton.wakeup.memberInfo.entity.MemberInfo;
+import hackerton.wakeup.memberInfo.repository.MemberInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AlarmService {
+    private final MemberRepository memberRepository;
+    private final MemberInfoRepository memberInfoRepository;
+    private final CharacterRepository characterRepository;
+    private final AchievementRepository achievementRepository;
+
+    // 구간별 레벨에 따른 Point 획득 Map
+    private final Map<String, Integer> levelRangePointMap = new HashMap<>() {{
+        put("1-4", 10);
+        put("5-9", 30);
+        put("10-14", 70);
+        put("15-19", 100);
+        put("20-24", 200);
+        put("25-29", 300);
+        put("30-34", 400);
+        put("35-39", 500);
+        put("40-44", 700);
+    }};
+
+
+    public AlarmPostResponse postAlarm(String nickname, String tag, Boolean isSuccess) {
+        MemberInfo memberInfo = memberInfoRepository.findByNicknameAndTag(nickname, tag).get();
+        Member member = memberInfo.getMember();
+        LocalDateTime now = LocalDateTime.now();
+        String message = "";
+
+        // 'yyMMdd' 형식으로 변환하기 위한 포맷터를 생성
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyMMdd");
+
+        // 현재 시간을 'yyMMdd' 형식의 문자열로 변환
+        String formattedDate = now.format(formatter);
+        Character character = characterRepository.findByIdMember(member.getId()).get();
+
+        if (isSuccess) {
+            Integer characterLevel = character.getLevel();
+            Long characterExp = character.getExp();
+            characterExp = characterExp + 1;
+
+            // exp 레벨업 기준에 도달 했을 때와 아닐 때
+            if (characterExp > characterLevel * 5) {
+                Character modifiedCharacter = character.toBuilder()
+                        .level(characterLevel + 1)
+                        .exp(0L)
+                        .build();
+                characterRepository.save(modifiedCharacter);
+                Integer getPoint = getLevelUpPoint(characterLevel+1);
+                Member modifiedMember = member.toBuilder()
+                        .point(member.getPoint() + getPoint)
+                        .build();
+                memberRepository.save(modifiedMember);
+            } else {
+                Character modifiedCharacter = character.toBuilder()
+                        .exp(characterExp)
+                        .build();
+                characterRepository.save(modifiedCharacter);
+            }
+            Achievement achievement = achievementRepository.findByMemberAndDate(memberInfo.getMember(), formattedDate)
+                    .orElse(
+                            Achievement.builder()
+                                    .success(1)
+                                    .failure(0)
+                                    .date(formattedDate)
+                                    .member(member)
+                                    .build()
+                    );
+            Achievement modifiedachievement = achievement.toBuilder()
+                    .success(achievement.getSuccess()+1)
+                    .build();
+            achievementRepository.save(modifiedachievement);
+
+            message = "성공했습니다";
+        } else {
+            Achievement achievement = achievementRepository.findByMemberAndDate(memberInfo.getMember(), formattedDate)
+                    .orElse(
+                            Achievement.builder()
+                                    .success(0)
+                                    .failure(1)
+                                    .date(formattedDate)
+                                    .member(member)
+                                    .build()
+                    );
+            Achievement modifiedachievement = achievement.toBuilder()
+                    .failure(achievement.getFailure()+1)
+                    .build();
+            achievementRepository.save(modifiedachievement);
+            message = "실패했습니다";
+        }
+        return new AlarmPostResponse(memberInfo, character, message);
+    }
+    
+    
+    // 레벨업에 따른 포인트 획득 메서드
+    private int getLevelUpPoint(int level) {
+        if (level >= 1 && level <= 4) {
+            return levelRangePointMap.get("1-4");
+        } else if (level >= 5 && level <= 9) {
+            return levelRangePointMap.get("5-9");
+        } else if (level >= 10 && level <= 14) {
+            return levelRangePointMap.get("10-14");
+        } else if (level >= 15 && level <= 19) {
+            return levelRangePointMap.get("15-19");
+        } else if (level >= 20 && level <= 24) {
+            return levelRangePointMap.get("20-24");
+        } else if (level >= 25 && level <= 29) {
+            return levelRangePointMap.get("25-29");
+        } else if (level >= 30 && level <= 34) {
+            return levelRangePointMap.get("30-34");
+        } else if (level >= 35 && level <= 39) {
+            return levelRangePointMap.get("35-39");
+        } else if (level >= 40 && level <= 44) {
+            return levelRangePointMap.get("40-44");
+        } else {
+            // 기본값을 사용하거나 예외를 던질 수 있음
+            throw new IllegalArgumentException("레벨에 대한 경험치 기준을 찾을 수 없습니다.");
+        }
+    }
+
+}

--- a/src/main/java/hackerton/wakeup/alarm/service/dto/AlarmPostRequest.java
+++ b/src/main/java/hackerton/wakeup/alarm/service/dto/AlarmPostRequest.java
@@ -1,0 +1,10 @@
+package hackerton.wakeup.alarm.service.dto;
+
+import lombok.Data;
+
+@Data
+public class AlarmPostRequest {
+    private String nickname;
+    private String tag;
+    private Boolean isSuccess;
+}

--- a/src/main/java/hackerton/wakeup/alarm/service/dto/AlarmPostResponse.java
+++ b/src/main/java/hackerton/wakeup/alarm/service/dto/AlarmPostResponse.java
@@ -1,0 +1,21 @@
+package hackerton.wakeup.alarm.service.dto;
+
+import hackerton.wakeup.character.entity.Character;
+import hackerton.wakeup.member.entity.Member;
+import hackerton.wakeup.memberInfo.entity.MemberInfo;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class AlarmPostResponse {
+    private MemberInfo memberInfo;
+    private Character character;
+    private String message;
+
+    public AlarmPostResponse(MemberInfo memberInfo, Character character, String message) {
+        this.memberInfo = memberInfo;
+        this.message = message;
+        this.character = character;
+    }
+}

--- a/src/main/java/hackerton/wakeup/body/own/entity/OwnBodyAvatar.java
+++ b/src/main/java/hackerton/wakeup/body/own/entity/OwnBodyAvatar.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "OwnBodyAvatar")
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/hackerton/wakeup/body/part/entity/Body.java
+++ b/src/main/java/hackerton/wakeup/body/part/entity/Body.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "Body")
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/hackerton/wakeup/character/entity/Character.java
+++ b/src/main/java/hackerton/wakeup/character/entity/Character.java
@@ -1,6 +1,7 @@
 package hackerton.wakeup.character.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import hackerton.wakeup.body.own.entity.OwnBodyAvatar;
 import hackerton.wakeup.eyes.own.entity.OwnEyesAvatar;
@@ -15,10 +16,11 @@ import java.util.List;
 
 @Entity
 @Table(name = "Character")
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Character {
 
     @EmbeddedId

--- a/src/main/java/hackerton/wakeup/character/entity/CharacterId.java
+++ b/src/main/java/hackerton/wakeup/character/entity/CharacterId.java
@@ -6,7 +6,7 @@ import lombok.*;
 import java.io.Serializable;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/hackerton/wakeup/common/config/JpaConfig.java
+++ b/src/main/java/hackerton/wakeup/common/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package hackerton.wakeup.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+    // JpaConfig 클래스는 Auditing 기능을 활성화합니다.
+}

--- a/src/main/java/hackerton/wakeup/common/config/SwaggerConfig.java
+++ b/src/main/java/hackerton/wakeup/common/config/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package hackerton.wakeup.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        String jwt = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
+        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+                .name(jwt)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+        );
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo())
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+    private Info apiInfo() {
+        return new Info()
+                .title("일오나 Back-end API") // API의 제목
+                .description("일오나 api 문서") // API에 대한 설명
+                .version("1.0.0"); // API의 버전
+    }
+}

--- a/src/main/java/hackerton/wakeup/common/domain/BaseEntity.java
+++ b/src/main/java/hackerton/wakeup/common/domain/BaseEntity.java
@@ -1,0 +1,29 @@
+package hackerton.wakeup.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Column(updatable = false, nullable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/hackerton/wakeup/eyes/own/entity/OwnEyesAvatar.java
+++ b/src/main/java/hackerton/wakeup/eyes/own/entity/OwnEyesAvatar.java
@@ -8,7 +8,7 @@ import lombok.*;
 
 @Entity
 @Table(name = "OwnEyesAvatar")
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/hackerton/wakeup/eyes/part/entity/Eyes.java
+++ b/src/main/java/hackerton/wakeup/eyes/part/entity/Eyes.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "Eyes")
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/hackerton/wakeup/head/own/entity/OwnHeadAvatar.java
+++ b/src/main/java/hackerton/wakeup/head/own/entity/OwnHeadAvatar.java
@@ -8,7 +8,7 @@ import lombok.*;
 
 @Entity
 @Table(name = "OwnHeadAvatar")
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/hackerton/wakeup/head/part/entity/Head.java
+++ b/src/main/java/hackerton/wakeup/head/part/entity/Head.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "Head")
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/hackerton/wakeup/member/entity/Member.java
+++ b/src/main/java/hackerton/wakeup/member/entity/Member.java
@@ -1,5 +1,6 @@
 package hackerton.wakeup.member.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import hackerton.wakeup.character.entity.Character;
 import hackerton.wakeup.memberInfo.entity.MemberInfo;
@@ -9,10 +10,11 @@ import lombok.*;
 
 @Entity
 @Table(name = "Member")
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/hackerton/wakeup/memberInfo/entity/MemberInfo.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/entity/MemberInfo.java
@@ -1,6 +1,7 @@
 package hackerton.wakeup.memberInfo.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import hackerton.wakeup.member.entity.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
@@ -8,10 +9,11 @@ import lombok.*;
 
 @Entity
 @Table(name = "MemberInfo")
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class MemberInfo {
 
     @EmbeddedId

--- a/src/main/java/hackerton/wakeup/memberInfo/entity/MemberInfoId.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/entity/MemberInfoId.java
@@ -8,7 +8,7 @@ import lombok.*;
 import java.io.Serializable;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/hackerton/wakeup/memberInfo/repository/MemberInfoRepository.java
+++ b/src/main/java/hackerton/wakeup/memberInfo/repository/MemberInfoRepository.java
@@ -13,4 +13,5 @@ public interface MemberInfoRepository extends JpaRepository<MemberInfo, MemberIn
 
     Optional<MemberInfo> findById(MemberInfoId id);
     Optional<MemberInfo> findByIdMember(Long member);
+    Optional<MemberInfo> findByNicknameAndTag(String nickname, String tag);
 }

--- a/src/main/java/hackerton/wakeup/mouth/own/entity/OwnMouthAvatar.java
+++ b/src/main/java/hackerton/wakeup/mouth/own/entity/OwnMouthAvatar.java
@@ -8,7 +8,7 @@ import lombok.*;
 
 @Entity
 @Table(name = "OwnMouthAvatar")
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/hackerton/wakeup/mouth/part/entity/Mouth.java
+++ b/src/main/java/hackerton/wakeup/mouth/part/entity/Mouth.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "mouth")
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor


### PR DESCRIPTION
## 연관된 이슈

#45, #46 

## 작업 내용
- 성공 및 실패 횟수 조회
- 날짜에 따라, 요일에 따라 성공 및 실패 횟수 조회
- 레벨업 후 초기화 된 다음에 쌓인 성공횟수 및 레벨업까지 필요한 횟수 조회
- 레벨업 후 초기화 된 다음에 쌓인 성공횟수 / 레벨업까지 필요한 횟수 조회

## 기타(특이사항 등)
- 보내는 데이터에 ID가 NULL임 -> 중복 조회 문제 및 동시성 문제로 NULL로 보내짐.
- 다만, 해당 레코드가 존재할 시 에는 정상적으로 작동함.
- 날짜별 성공 날짜는 "yyMMdd" 형식 ex) 240805
- 데이터형식은 다음과 같음.
"날짜": {
    "요일": {
        성공 실패 및 날짜 등의 데이터
    }
}

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/88f1675e-d6c6-482c-8ba4-c3baef224b6d)
현재 성공횟수 및 레벨업까지 필요한 횟수 조회
![image](https://github.com/user-attachments/assets/354bcf28-e117-41c2-b50c-f02b0767eedf)

## 💬리뷰 요구사항(선택)
- PR에 코드 사진을 첨부하기 보다는 커밋  기록 등을 통해서 코드를 봐주시면 될 거 같습니다.
- 날짜를 2주전부터로 널널하게 잡았는데, 효율 및 성능 측면 그리고 쓸데없이 너무 많은 데이터를 보내는 건지에 대한 의문이 있습니다. 이에 대해 어떻게 생각하는 지 궁금합니다.